### PR TITLE
Limit filename length when decrypting note title

### DIFF
--- a/decrypt.html
+++ b/decrypt.html
@@ -210,7 +210,16 @@
       // Remove slashes
       name = name.replace(/\//g, "").replace(/\\+/g, "");
 
-      name = `${item.content_type}/${name}-${item.uuid.split("-")[0]}.txt`
+      // ('-' + first section of UUID + '.txt')
+      var filenameEnd = `-${item.uuid.split("-")[0]}.txt`
+
+      // Standard max filename length is 255
+      // Slice the note name down to allow filenameEnd
+      if(name.length > (255 - filenameEnd.length)) {
+        name = name.slice(0, (255 - filenameEnd.length));
+      }
+
+      name = `${item.content_type}/${name}${filenameEnd}`
       zip.file(name, contents);
     }
 


### PR DESCRIPTION
Note titles could extend past the filename standard length of 255 and when decrypting to a zip you could not export the file due to the filename length being too long.

This cuts the name portion down to allow for the unique id to be added and the file extension.